### PR TITLE
Fixing the options not displaying properly.

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -104,6 +104,7 @@ const store = useStore();
 const stompClient = new StompClient();
 
 //Prompt the store/options to load the options
+store.commit("options/init");
 store.commit("options/loadOptions");
 
 let setupPromise = setupConnection();

--- a/frontend/src/options/store/optionsModule.js
+++ b/frontend/src/options/store/optionsModule.js
@@ -100,8 +100,12 @@ const optionsModule = {
   },
   mutations: {
     init(state) {
-      state.options = [];
       //TODO: load from server
+      let allOptions = state.options.map(
+        (section) => section.options || [section]
+      );
+      allOptions = [].concat(...allOptions);
+      allOptions.forEach((option) => option.updateDisplayProps());
     },
     loadOptions(state) {
       //TODO: load locally
@@ -119,7 +123,6 @@ const optionsModule = {
               option.value = value;
             }
           });
-          state.options.forEach((option) => option.updateDisplayProps());
           allOptions.forEach((option) => option.updateDisplayProps());
         }
       } catch (e) {

--- a/frontend/src/options/store/optionsModule.js
+++ b/frontend/src/options/store/optionsModule.js
@@ -105,6 +105,7 @@ const optionsModule = {
         (section) => section.options || [section]
       );
       allOptions = [].concat(...allOptions);
+      state.options.forEach((option) => option.updateDisplayProps());
       allOptions.forEach((option) => option.updateDisplayProps());
     },
     loadOptions(state) {
@@ -123,6 +124,7 @@ const optionsModule = {
               option.value = value;
             }
           });
+          state.options.forEach((option) => option.updateDisplayProps());
           allOptions.forEach((option) => option.updateDisplayProps());
         }
       } catch (e) {


### PR DESCRIPTION
This issue was caused by an oversight on the loading options routine.
It would only update the options visibility if the user had options saved in localStorage.
Now we always update the options display props.