### PR TITLE
Changing to a higher ladder than you have reached as a moderator breaks.

### DIFF
--- a/frontend/src/ladder/entities/ranker.js
+++ b/frontend/src/ladder/entities/ranker.js
@@ -3,6 +3,7 @@ import Decimal from "break_infinity.js";
 //
 class Ranker {
   constructor(data) {
+    if (!data) data = Ranker.placeholder();
     this.accountId = data.accountId;
     this.username = data.username;
     this.rank = data.rank;


### PR DESCRIPTION
The issue was that we passed undefined data into the ranker constructor.
Checking for this and replacing it with the placeholder fixes it.
Partially fixes the issue, but a different kind of bug still remains.