### PR TITLE
cleanup: Centralising sound init

### DIFF
--- a/frontend/src/chat/components/ChatWindow.vue
+++ b/frontend/src/chat/components/ChatWindow.vue
@@ -33,14 +33,7 @@ import { computed, inject, onUpdated, ref } from "vue";
 import ChatMessage from "@/chat/components/ChatMessage";
 import ChatInput from "@/chat/components/ChatInput";
 import PaginationGroup from "@/components/PaginationGroup";
-
-import { Sounds } from "@/modules/sounds";
 import API from "@/websocket/wsApi";
-
-Sounds.register(
-  "mention",
-  "https://assets.mixkit.co/sfx/download/mixkit-software-interface-start-2574.wav"
-);
 
 const store = useStore();
 const stompClient = inject("$stompClient");

--- a/frontend/src/modules/sounds.js
+++ b/frontend/src/modules/sounds.js
@@ -1,6 +1,10 @@
 let Sounds = {
   setStore: (store) => {
     Sounds.store = store;
+    //Initialize the sounds
+    Sounds.register("gotFirstJingle", require("@/assets/gotFirstJingle.wav"));
+    Sounds.register("promotionJingle", require("@/assets/promotionJingle.wav"));
+    Sounds.register("mention", require("@/assets/gotFirstJingle.wav"));
   },
   register: (name, url) => {
     Sounds.store.commit({

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,20 +1,19 @@
-import { createStore } from "vuex";
-import ladderModule from "@/store/modules/ladder/ladderModule";
-import chatModule from "@/chat/store/chatModule";
+import API from "@/websocket/wsApi";
+import Cookies from "js-cookie";
+import Decimal from "break_infinity.js";
 import Settings from "@/store/entities/settings";
+import { Sounds } from "@/modules/sounds";
 import UserDetails from "@/store/entities/userDetails";
+import chatModule from "@/chat/store/chatModule";
+import { computed } from "vue";
+import { createStore } from "vuex";
+import hookModule from "@/store/modules/hookModule";
+import ladderModule from "@/store/modules/ladder/ladderModule";
+import moderationModule from "@/moderation/store/moderationModule";
 import { numberformat } from "swarm-numberformat";
 import optionsModule from "@/options/store/optionsModule";
 import soundsModule from "@/sounds/store/soundsModule";
-import moderationModule from "@/moderation/store/moderationModule";
 import versioningModule from "@/versioning/store/versioningModule";
-import hookModule from "@/store/modules/hookModule";
-
-import { computed } from "vue";
-import { Sounds } from "@/modules/sounds";
-import Cookies from "js-cookie";
-import API from "@/websocket/wsApi";
-import Decimal from "break_infinity.js";
 
 let promotionJingleVolume;
 let reachingFirstSound;
@@ -231,7 +230,6 @@ reachingFirstSound = computed(() =>
 );
 
 Sounds.setStore(store);
-Sounds.register("promotionJingle", require("@/assets/promotionJingle.wav"));
 optionsModule.setStore(store);
 store.registerModule("options", optionsModule);
 export default store;

--- a/frontend/src/store/modules/ladder/stats/statsModule.js
+++ b/frontend/src/store/modules/ladder/stats/statsModule.js
@@ -14,9 +14,7 @@ const reachingFirstSound = computed(() =>
 export default {
   namespaced: true,
   state: () => {
-    setTimeout(() => {
-      Sounds.register("gotFirstJingle", require("@/assets/gotFirstJingle.wav"));
-    }, 0);
+    setTimeout(() => {}, 0);
     return {
       growingRankerCount: 1,
       pointsNeededForManualPromote: new Decimal(Infinity),


### PR DESCRIPTION
This patch will centralise the initialisation of all sounds to the "sounds.js"
This grants more controll over the sounds and a central point where to look for names etc.
I have for now omitted a changelog entry, as this is nothing the user will notice at all.