### PR TITLE
CHEAP and EXPENSIVE ladder modifiers

### DIFF
--- a/backend/src/main/java/de/kaliburg/morefair/game/UpgradeUtils.java
+++ b/backend/src/main/java/de/kaliburg/morefair/game/UpgradeUtils.java
@@ -4,6 +4,9 @@ import de.kaliburg.morefair.FairConfig;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
+import java.util.Set;
+
+import de.kaliburg.morefair.game.round.LadderType;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -29,6 +32,19 @@ public class UpgradeUtils {
     BigInteger result = ladder.pow(currentUpgrade + 1);
 
     return result;
+  }
+
+  public BigInteger buyUpgradeCost(Integer ladderNumber, Integer currentUpgrade, Set<LadderType> ladderTypes) {
+    BigDecimal costMulti = BigDecimal.valueOf(1.0f);
+    if (ladderTypes.contains(LadderType.CHEAP)) {
+      costMulti = BigDecimal.valueOf(0.5f);
+    }
+    if (ladderTypes.contains(LadderType.EXPENSIVE)) {
+      costMulti = BigDecimal.valueOf(1.5f);
+    }
+    BigDecimal ladder = BigDecimal.valueOf(ladderNumber + 1);
+    BigDecimal result = ladder.pow(currentUpgrade + 1).multiply(costMulti);
+    return result.toBigInteger();
   }
 
   public BigInteger throwVinegarCost(Integer ladderNum) {

--- a/backend/src/main/java/de/kaliburg/morefair/game/round/LadderService.java
+++ b/backend/src/main/java/de/kaliburg/morefair/game/round/LadderService.java
@@ -388,7 +388,7 @@ public class LadderService implements ApplicationListener<AccountServiceEvent> {
   boolean buyBias(Event event, LadderEntity ladder) {
     try {
       RankerEntity ranker = findActiveRankerOfAccountOnLadder(event.getAccountId(), ladder);
-      BigInteger cost = upgradeUtils.buyUpgradeCost(ladder.getNumber(), ranker.getBias());
+      BigInteger cost = upgradeUtils.buyUpgradeCost(ladder.getNumber(), ranker.getBias(), ladder.getTypes());
       if (ranker.getPoints().compareTo(cost) >= 0) {
         ranker.setPoints(BigInteger.ZERO);
         ranker.setBias(ranker.getBias() + 1);
@@ -413,7 +413,7 @@ public class LadderService implements ApplicationListener<AccountServiceEvent> {
   boolean buyMulti(Event event, LadderEntity ladder) {
     try {
       RankerEntity ranker = findActiveRankerOfAccountOnLadder(event.getAccountId(), ladder);
-      BigInteger cost = upgradeUtils.buyUpgradeCost(ladder.getNumber(), ranker.getMultiplier());
+      BigInteger cost = upgradeUtils.buyUpgradeCost(ladder.getNumber(), ranker.getMultiplier(), ladder.getTypes());
       if (ranker.getPower().compareTo(cost) >= 0) {
         ranker.setPoints(BigInteger.ZERO);
         ranker.setPower(BigInteger.ZERO);

--- a/backend/src/main/java/de/kaliburg/morefair/game/round/LadderType.java
+++ b/backend/src/main/java/de/kaliburg/morefair/game/round/LadderType.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public enum LadderType implements Comparable<LadderType> {
-  DEFAULT, TINY, SMALL, BIG, GIGANTIC, FREE_AUTO, NO_AUTO, ASSHOLE;
+  DEFAULT, TINY, SMALL, BIG, GIGANTIC, FREE_AUTO, NO_AUTO, ASSHOLE, CHEAP, EXPENSIVE;
 
   @Getter
   private int priority = 0;

--- a/backend/src/main/java/de/kaliburg/morefair/game/round/LadderTypeBuilder.java
+++ b/backend/src/main/java/de/kaliburg/morefair/game/round/LadderTypeBuilder.java
@@ -17,6 +17,7 @@ public class LadderTypeBuilder {
   private static final Random random = new Random();
   private final Map<LadderType, Float> ladderSizeTypeWeights = new HashMap<>();
   private final Map<LadderType, Float> ladderAutoTypeWeights = new HashMap<>();
+  private final Map<LadderType, Float> ladderCostTypeWeights = new HashMap<>();
   @Setter
   @Accessors(chain = true)
   private Set<RoundType> roundTypes = EnumSet.noneOf(RoundType.class);
@@ -40,6 +41,10 @@ public class LadderTypeBuilder {
     ladderAutoTypeWeights.put(LadderType.FREE_AUTO, 5.f);
     ladderAutoTypeWeights.put(LadderType.NO_AUTO, 2.f);
     ladderAutoTypeWeights.put(LadderType.DEFAULT, 100.f);
+
+    ladderCostTypeWeights.put(LadderType.CHEAP, 5.f);
+    ladderCostTypeWeights.put(LadderType.EXPENSIVE,5.f);
+    ladderCostTypeWeights.put(LadderType.DEFAULT, 100.f);
   }
 
   private void handlePreviousLadderType(LadderType ladderType) {
@@ -50,6 +55,9 @@ public class LadderTypeBuilder {
       }
       if (ladderAutoTypeWeights.containsKey(ladderType)) {
         ladderAutoTypeWeights.put(ladderType, ladderAutoTypeWeights.get(ladderType) / 2);
+      }
+      if (ladderCostTypeWeights.containsKey(ladderType)) {
+        ladderCostTypeWeights.put(ladderType, ladderCostTypeWeights.get(ladderType) / 2);
       }
 
       return;
@@ -80,6 +88,10 @@ public class LadderTypeBuilder {
         ladderSizeTypeWeights.put(LadderType.BIG, 0.f);
         ladderSizeTypeWeights.put(LadderType.GIGANTIC, 0.f);
         ladderSizeTypeWeights.put(LadderType.DEFAULT, 0.f);
+        ladderCostTypeWeights.put(LadderType.CHEAP,
+            ladderCostTypeWeights.get(LadderType.CHEAP) * 2);
+        ladderCostTypeWeights.put(LadderType.EXPENSIVE,
+            ladderCostTypeWeights.get(LadderType.EXPENSIVE) / 2);
       }
       case AUTO -> {
         ladderAutoTypeWeights.put(LadderType.FREE_AUTO,
@@ -92,6 +104,9 @@ public class LadderTypeBuilder {
         ladderSizeTypeWeights.put(LadderType.BIG, 1.f);
         ladderSizeTypeWeights.put(LadderType.GIGANTIC, 1.f);
         ladderSizeTypeWeights.put(LadderType.DEFAULT, 0.f);
+        ladderCostTypeWeights.put(LadderType.CHEAP, 1.f);
+        ladderCostTypeWeights.put(LadderType.EXPENSIVE, 1.f);
+        ladderCostTypeWeights.put(LadderType.DEFAULT, 1.f);
       }
       case SLOW -> {
         ladderSizeTypeWeights.put(LadderType.TINY, ladderSizeTypeWeights.get(LadderType.TINY) / 2);
@@ -103,6 +118,10 @@ public class LadderTypeBuilder {
         ladderAutoTypeWeights.put(LadderType.NO_AUTO, 0.f);
         ladderAutoTypeWeights.put(LadderType.FREE_AUTO,
             ladderAutoTypeWeights.get(LadderType.FREE_AUTO) * 2);
+        ladderCostTypeWeights.put(LadderType.CHEAP,
+            ladderCostTypeWeights.get(LadderType.CHEAP) / 2);
+        ladderCostTypeWeights.put(LadderType.EXPENSIVE,
+            ladderCostTypeWeights.get(LadderType.EXPENSIVE) * 2);
       }
       default -> {
         // do nothing
@@ -140,6 +159,7 @@ public class LadderTypeBuilder {
 
     ladderTypes.add(getRandomLadderType(ladderSizeTypeWeights, "Size"));
     ladderTypes.add(getRandomLadderType(ladderAutoTypeWeights, "Auto"));
+    ladderTypes.add(getRandomLadderType(ladderCostTypeWeights, "Cost"));
     if (ladderTypes.size() > 1) {
       ladderTypes.remove(LadderType.DEFAULT);
     }

--- a/backend/src/main/java/de/kaliburg/morefair/game/round/LadderTypeBuilder.java
+++ b/backend/src/main/java/de/kaliburg/morefair/game/round/LadderTypeBuilder.java
@@ -76,7 +76,6 @@ public class LadderTypeBuilder {
   private void handleRoundTypes(RoundType roundType) {
     switch (roundType) {
       case FAST -> {
-        ladderSizeTypeWeights.put(LadderType.SMALL, ladderSizeTypeWeights.get(LadderType.DEFAULT));
         ladderSizeTypeWeights.put(LadderType.TINY, ladderSizeTypeWeights.get(LadderType.TINY) * 2);
         ladderSizeTypeWeights.put(LadderType.BIG, 0.f);
         ladderSizeTypeWeights.put(LadderType.GIGANTIC, 0.f);
@@ -84,10 +83,8 @@ public class LadderTypeBuilder {
       }
       case AUTO -> {
         ladderAutoTypeWeights.put(LadderType.FREE_AUTO,
-            ladderAutoTypeWeights.get(LadderType.DEFAULT));
+            ladderAutoTypeWeights.get(LadderType.FREE_AUTO) * 10);
         ladderAutoTypeWeights.put(LadderType.DEFAULT, 0.f);
-        ladderAutoTypeWeights.put(LadderType.NO_AUTO,
-            ladderAutoTypeWeights.get(LadderType.NO_AUTO) * 2f);
       }
       case CHAOS -> {
         ladderSizeTypeWeights.put(LadderType.TINY, 1.f);
@@ -97,12 +94,12 @@ public class LadderTypeBuilder {
         ladderSizeTypeWeights.put(LadderType.DEFAULT, 0.f);
       }
       case SLOW -> {
+        ladderSizeTypeWeights.put(LadderType.TINY, ladderSizeTypeWeights.get(LadderType.TINY) / 2);
+        ladderSizeTypeWeights.put(LadderType.SMALL,
+            ladderSizeTypeWeights.get(LadderType.SMALL) / 2);
         ladderSizeTypeWeights.put(LadderType.BIG, ladderSizeTypeWeights.get(LadderType.BIG) * 2);
         ladderSizeTypeWeights.put(LadderType.GIGANTIC,
             ladderSizeTypeWeights.get(LadderType.GIGANTIC) * 5);
-        ladderSizeTypeWeights.put(LadderType.SMALL,
-            ladderSizeTypeWeights.get(LadderType.SMALL) / 2);
-        ladderSizeTypeWeights.put(LadderType.TINY, ladderSizeTypeWeights.get(LadderType.TINY) / 2);
         ladderAutoTypeWeights.put(LadderType.NO_AUTO, 0.f);
         ladderAutoTypeWeights.put(LadderType.FREE_AUTO,
             ladderAutoTypeWeights.get(LadderType.FREE_AUTO) * 2);

--- a/frontend/src/ladder/utils/ladderUtils.js
+++ b/frontend/src/ladder/utils/ladderUtils.js
@@ -39,9 +39,16 @@ export default {
   getVinegarThrowCost(settings, ladder) {
     return settings.baseVinegarNeededToThrow.mul(new Decimal(ladder.number));
   },
-  getNextUpgradeCost(ladder, currentUpgrade) {
+  getNextUpgradeCost(ladder, currentUpgrade, ladderTypes) {
+    let costMult = 1;
+    if (ladderTypes.indexOf("CHEAP") >= 0) {
+      costMult = 0.5;
+    }
+    if (ladderTypes.indexOf("EXPENSIVE") >= 0) {
+      costMult = 1.5;
+    }
     return new Decimal(
-      Math.round(Math.pow(ladder.number + 1, currentUpgrade + 1))
+      Math.round(Math.pow(ladder.number + 1, currentUpgrade + 1) * costMult)
     );
   },
   calculatePointsNeededForPromote(settings, ladder) {

--- a/frontend/src/store/modules/ladder/ladderGetters.js
+++ b/frontend/src/store/modules/ladder/ladderGetters.js
@@ -46,7 +46,11 @@ export default {
     return ladderUtils.canThrowVinegar(rootState.settings, state);
   },
   getNextUpgradeCost: (state) => (currentUpgrade) => {
-    return ladderUtils.getNextUpgradeCost(state, currentUpgrade);
+    return ladderUtils.getNextUpgradeCost(
+      state,
+      currentUpgrade,
+      Array.from(state.types).join(",")
+    );
   },
   getVinegarThrowCost(state, _, rootState) {
     return ladderUtils.getVinegarThrowCost(rootState.settings, state);

--- a/frontend/src/versioning/store/versioningModule.js
+++ b/frontend/src/versioning/store/versioningModule.js
@@ -5,6 +5,14 @@ const versioningModule = {
   state: () => {
     return {
       versions: [
+        new Version("MINOR", "CHEAP and EXPENSIVE Ladder Types", {
+          features: [
+            "CHEAP ladders have the cost to bias and multi reduced by 50%.",
+            "EXPENSIVE ladders have the cost to bias and multi increased by 50%.",
+            "CHEAP ladders are more common on FAST rounds, and EXPENSIVE ladders are more common on SLOW rounds.",
+            "CHAOS rounds have a much higher chance of rolling CHEAP or EXPENSIVE ladders, with equal chance for each.",
+          ],
+        }),
         new Version("PATCH", "Spectate Asshole Ladder", {
           features: [
             "Adding an option to being able to spectate the asshole ladder (experimental)",


### PR DESCRIPTION
Not sure why the original one closed...

As before:

These modifiers reduce or increase the cost of purchasing multi and bias by 50% respectively.

Base weighting is 5/100 for each modifier

CHEAP is more common on FAST rounds
EXPENSIVE is more common on SLOW rounds

CHAOS sets their weighting to 1/3
