### PR TITLE
Adding ETA to vinegar throw to UI

### DIFF
--- a/frontend/src/components/ladder/LadderWindowBody.vue
+++ b/frontend/src/components/ladder/LadderWindowBody.vue
@@ -170,7 +170,7 @@ const multiButtonLabel = computed<string>(() => {
 
 const vinegarButtonLabel = computed<string>(() => {
   const eta = useEta(yourRanker.value).toVinegarThrow();
-  if (eta === 0) return `${lang("vinegar")}`;
+  if (eta === 0 || eta === Infinity) return `${lang("vinegar")}`;
   return `${lang("vinegar")} (${useTimeFormatter(eta)})`;
 });
 

--- a/frontend/src/components/ladder/LadderWindowBody.vue
+++ b/frontend/src/components/ladder/LadderWindowBody.vue
@@ -82,7 +82,7 @@
         class="w-full rounded-l-none border-l-0 whitespace-nowrap"
         @click="throwVinegar"
       >
-        {{ lang("vinegar") }}
+        {{ vinegarButtonLabel }}
       </FairButton>
       <FairButton
         v-else
@@ -166,6 +166,12 @@ const multiButtonLabel = computed<string>(() => {
     ladderUtils.getYourMultiCost.value
   );
   return `+${lang("multi_short")} (${useTimeFormatter(eta)})`;
+});
+
+const vinegarButtonLabel = computed<string>(() => {
+  const eta = useEta(yourRanker.value).toVinegarThrow();
+  if (eta === 0) return `${lang("vinegar")}`;
+  return `${lang("vinegar")} (${useTimeFormatter(eta)})`;
 });
 
 const yourFormattedMulti = computed<string>(() => {

--- a/frontend/src/composables/useEta.ts
+++ b/frontend/src/composables/useEta.ts
@@ -180,12 +180,28 @@ export const useEta = (ranker: Ranker) => {
 
   function toVinegarThrow(): number {
     if (!ranker.growing) return 0;
-    const secondsToVinegar =
-      ladderUtils.getVinegarThrowCost.value.cmp(ranker.vinegar) >= 0
-        ? ladderUtils.getVinegarThrowCost.value
-            .sub(ranker.vinegar)
-            .div(ranker.grapes)
-        : new Decimal(0);
+
+    let secondsToVinegar: Decimal;
+
+    if (
+      ranker.rank === ladder.state.rankers.length &&
+      ladder.state.rankers.length >= 1
+    ) {
+      // TODO: When grape modifiers are implemented, acceleration can be changed.
+      const acceleration = 2;
+      const a = new Decimal(acceleration).div(2);
+      const b = ranker.grapes.sub(1);
+      const c = ranker.vinegar.sub(ladderUtils.getVinegarThrowCost.value);
+
+      secondsToVinegar = solveQuadratic(a, b, c);
+    } else {
+      secondsToVinegar =
+        ladderUtils.getVinegarThrowCost.value.cmp(ranker.vinegar) >= 0
+          ? ladderUtils.getVinegarThrowCost.value
+              .sub(ranker.vinegar)
+              .div(ranker.grapes)
+          : new Decimal(0);
+    }
 
     return secondsToVinegar.toNumber();
   }

--- a/frontend/src/composables/useEta.ts
+++ b/frontend/src/composables/useEta.ts
@@ -178,6 +178,18 @@ export const useEta = (ranker: Ranker) => {
     return Math.max(etaRequirement, toFirst() + 30);
   }
 
+  function toVinegarThrow(): number {
+    if (!ranker.growing) return 0;
+    const secondsToVinegar =
+      ladderUtils.getVinegarThrowCost.value.cmp(ranker.vinegar) >= 0
+        ? ladderUtils.getVinegarThrowCost.value
+            .sub(ranker.vinegar)
+            .div(ranker.grapes)
+        : new Decimal(0);
+
+    return secondsToVinegar.toNumber();
+  }
+
   return {
     toRanker,
     toPoints,
@@ -186,6 +198,7 @@ export const useEta = (ranker: Ranker) => {
     toFirst,
     toPromotionRequirement,
     toPromote,
+    toVinegarThrow,
   };
 };
 


### PR DESCRIPTION
There are two variants implemented which will be used in the following scenarios:
- If the ranker is experiencing grape gain:
    - solveQuadratic is used to yield a more accurate result.
- If the ranker is not experiencing grape gain:
    - A simple division of the vinegar deficit by the ranker's grapes is used

I believe that these two implementations used together yield a more accurate ETA over using only one.