### PR TITLE
Ignore list

### DIFF
--- a/frontend/src/components/options/OptionsEditableIgnore.vue
+++ b/frontend/src/components/options/OptionsEditableIgnore.vue
@@ -1,0 +1,110 @@
+<template>
+  <div
+    class="flex flex-col justify-between"
+    :class="{ 'opacity-50': !isActive }"
+  >
+    <div class="select-none overflow-hidden">{{ formattedName }}:</div>
+    <div
+      class="flex flex-col border-1 border-button-border w-fit items-center py-1 space-y-0.5"
+    >
+      <div class="flex flex-row">
+        <input
+          :disabled="!isActive"
+          :value="input"
+          class="bg-transparent border-button-border border-r-0 border-1 border-dashed w-32 px-1"
+          @input="input = $event.target.value"
+          @keydown.enter="add"
+        />
+        <button
+          :class="{
+            'hover:bg-button-bg-hover hover:text-button-text-hover': isActive,
+            'pointer-events-none': !isActive,
+          }"
+          :disabled="!isActive"
+          class="border-1 border-button-border rounded-l-none rounded-sm px-1 w-16"
+          @click="add"
+        >
+          Add
+        </button>
+      </div>
+      <div
+        v-for="(entry, index) in option.value"
+        :key="index"
+        class="flex flex-row"
+        :class="{
+          'select-none pointer-events-none': !isActive,
+        }"
+      >
+        <div
+          class="w-32 overflow-hidden whitespace-nowrap border-button-border border-1 border-r-0 pl-1 text-text-dark select-all"
+        >
+          {{ entry }}
+        </div>
+        <button
+          :disabled="!isActive"
+          :class="{
+            'hover:bg-button-bg-hover hover:text-button-text-hover': isActive,
+            'pointer-events-none': !isActive,
+          }"
+          class="border-1 border-button-border rounded-l-none rounded-sm px-1 w-16"
+          @click="remove(index)"
+        >
+          X
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref } from "vue";
+import { useLang } from "~/composables/useLang";
+
+const props = defineProps({
+  option: { type: Object, required: true },
+  label: { type: String, required: true },
+});
+
+const lang = useLang("options");
+
+const input = ref<string>("");
+
+const isActive = computed<boolean>(() => {
+  return props.option.isActive();
+});
+
+const formattedName = computed(() => {
+  return lang(props.label);
+});
+
+const emit = defineEmits<{
+  (event: "update", value: string[]): void;
+}>();
+
+function add() {
+  if (!isActive.value) return;
+
+  if (!Array.isArray(props.option.value)) {
+    emit("update", []);
+    return;
+  }
+
+  if (input.value === "" || props.option.value.includes(input.value)) {
+    return;
+  }
+
+  const newList = [...props.option.value, input.value];
+  emit("update", newList);
+  input.value = "";
+}
+
+function remove(index: number) {
+  if (!isActive.value) return;
+
+  const newList = [...props.option.value];
+  newList.splice(index, 1);
+  emit("update", newList);
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/frontend/src/components/options/OptionsSection.vue
+++ b/frontend/src/components/options/OptionsSection.vue
@@ -32,6 +32,12 @@
         :option="entry.value"
         @update="entry.value.set($event)"
       />
+      <OptionsEditableIgnore
+        v-else-if="entry.value instanceof EditableIgnoreOption"
+        :label="entry.key"
+        :option="entry.value"
+        @update="entry.value.set($event)"
+      />
       <OptionsEditableThemeURL
         v-else-if="entry.value instanceof EditableThemeURLOption"
         :label="entry.key"
@@ -50,6 +56,7 @@ import OptionsRange from "../../components/options/OptionsRange.vue";
 import {
   BooleanOption,
   EditableMentionsOption,
+  EditableIgnoreOption,
   EditableThemeURLOption,
   EnumOption,
   IntegerOption,
@@ -57,6 +64,7 @@ import {
 } from "~/store/entities/option";
 import { useLang } from "~/composables/useLang";
 import OptionsEditableMentions from "~/components/options/OptionsEditableMentions.vue";
+import OptionsEditableIgnore from "~/components/options/OptionsEditableIgnore.vue";
 import OptionsEditableThemeURL from "~/components/options/OptionsEditableThemeURL.vue";
 import OptionsInteger from "~/components/options/OptionsInteger.vue";
 

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -68,6 +68,7 @@ options:
   enableSpectateAssholeLadder: Enable spectating asshole ladder
   hideHelpText: Hide help text
   subscribedMentions: Subscribed mentions
+  ignoredPlayers: Ignored rankers (by ranker id)
   playSoundOnMention: Play sound on mention
   playSoundOnGotFirst: Play sound on reaching first
   playSoundOnPromotion: Play sound on promotion

--- a/frontend/src/store/chat.ts
+++ b/frontend/src/store/chat.ts
@@ -165,7 +165,7 @@ export const useChatStore = defineStore("chat", () => {
     if (
       ignorable(message) &&
       useOptionsStore().state.chat.ignoredPlayers.value.includes(
-        message.accountId.toString(),
+        message.accountId.toString()
       )
     ) {
       return;

--- a/frontend/src/store/chat.ts
+++ b/frontend/src/store/chat.ts
@@ -147,10 +147,27 @@ export const useChatStore = defineStore("chat", () => {
     getChat(ChatType.LADDER, newNumber);
   }
 
+  function ignorable(msg: Message): boolean {
+    return (
+      msg.chatType !== ChatType.MOD &&
+      msg.chatType !== ChatType.SYSTEM &&
+      msg.accountId !== useAccountStore().state.accountId
+    );
+  }
+
   function addMessage(body: OnChatEventBody): void {
     const message = new Message(body);
     const messages = state.messages.get(message.chatType);
     if (messages === undefined) {
+      return;
+    }
+
+    if (
+      ignorable(message) &&
+      useOptionsStore().state.chat.ignoredPlayers.value.includes(
+        message.accountId.toString(),
+      )
+    ) {
       return;
     }
 

--- a/frontend/src/store/entities/option.ts
+++ b/frontend/src/store/entities/option.ts
@@ -74,6 +74,8 @@ export class EditableStringListOption extends Option<string[]> {}
 
 export class EditableMentionsOption extends EditableStringListOption {}
 
+export class EditableIgnoreOption extends EditableStringListOption {}
+
 export class EditableThemeURLOption extends EditableStringListOption {}
 
 export const ObjectFunctions = ["callback", "isActive"];

--- a/frontend/src/store/options.ts
+++ b/frontend/src/store/options.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import {
   BooleanOption,
   EditableMentionsOption,
+  EditableIgnoreOption,
   EditableThemeURLOption,
   EnumOption,
   IntegerOption,
@@ -54,6 +55,7 @@ const defaultValues = {
   }),
   chat: new OptionsGroup({
     subscribedMentions: new EditableMentionsOption(["here"]),
+    ignoredPlayers: new EditableIgnoreOption([]),
   }),
   sound: new OptionsGroup({
     playSoundOnPromotion: new BooleanOption(false).setCallback((value) => {


### PR DESCRIPTION
Adds a new option to the settings to set a list of ranker IDs from which messages will not be printed to the chat.

This does not apply retroactively until page reload.

Messages cannot be ignored from the SYSTEM or MOD channels, or if the sender is the ranker themselves.

The mod chat view is unaffected.