### PR TITLE
Update useEta.ts

### DIFF
--- a/frontend/src/composables/useEta.ts
+++ b/frontend/src/composables/useEta.ts
@@ -23,7 +23,7 @@ function resetCache() {
 
 function getPowerGainDifferenceToRank(ranker: Ranker, targetRank = 1): Decimal {
   const rank = ranker.rank;
-  if (rank < 1 || !isFinite(rank)) return new Decimal(0);
+  if (rank <= 1 || !isFinite(rank)) return new Decimal(0);
 
   const powerGainAtStart = ranker.getPowerPerSecond(rank);
   const powerGainAtEnd = ranker.getPowerPerSecond(targetRank + 1);


### PR DESCRIPTION
For the ETA between rankers, the ranker in rank 1 should be assumed to have 0 powergain. Currently the result of the calculation is that the ranker in rank 1 is assumed to have half the powergain they would have in rank 2.